### PR TITLE
NPC-only craft indicators and non-memorized labels

### DIFF
--- a/src/app/models/Presenters/Recipe.php
+++ b/src/app/models/Presenters/Recipe.php
@@ -66,4 +66,22 @@ class Recipe extends \Robbo\Presenter\Presenter
 
         return "&gt; ".implode(", ", $byproducts)."\n";
     }
+    
+    public function presentLabels()
+    {
+        $labelArray = [];
+        $neverlearn = $this->object->never_learn;
+        if ($neverlearn) {
+            $labelArray[] = '<span class="label label-warning">Cannot Be Memorized</span><br>';
+        }
+
+        $suffix = $this->object->id_suffix;
+        if (stripos($suffix, "npc") !== false) {
+            $labelArray[] = '<span class="label label-warning">NPC Recipe</span><br>';
+        } else {
+            $labelArray[] = '<span class="label label-success">Player Recipe</span><br>';
+        }
+
+        return implode(" ", $labelArray);
+    }
 }

--- a/src/app/models/Recipe.php
+++ b/src/app/models/Recipe.php
@@ -123,4 +123,12 @@ class Recipe implements Robbo\Presenter\PresentableInterface
     {
         return $this->data->repo_id;
     }
+    
+    public function getIsNpcOnly()
+    {
+        if (isset($this->data->id_suffix)) {
+            return $this->data->id_suffix == "npc";
+        }
+        return false;
+    }
 }

--- a/src/app/models/Recipe.php
+++ b/src/app/models/Recipe.php
@@ -123,12 +123,4 @@ class Recipe implements Robbo\Presenter\PresentableInterface
     {
         return $this->data->repo_id;
     }
-    
-    public function getIsNpcOnly()
-    {
-        if (isset($this->data->id_suffix)) {
-            return $this->data->id_suffix == "npc";
-        }
-        return false;
-    }
 }

--- a/src/app/views/items/craft.blade.php
+++ b/src/app/views/items/craft.blade.php
@@ -20,6 +20,7 @@
 <div class="row">
 <div class="col-md-6">
 @foreach ($item->recipes as $recipe)
+  {{ $recipe->labels }}
   Skill used: {{{ $recipe->skill_used }}} <br>
   Required skills: {{ $recipe->skillsRequired }} <br>
   Difficulty: {{{ $recipe->difficulty }}}<br>


### PR DESCRIPTION
For issue #9.

![npc_recipe_indicator2](https://user-images.githubusercontent.com/9610892/46324292-51184700-c5b8-11e8-9238-a127859f9b94.png)

This reuses the label CSS to add indicators to the recipes in the craft list.
