### PR TITLE
Add visible obsolete label for recipes disabled in game.

### DIFF
--- a/src/app/models/Presenters/Recipe.php
+++ b/src/app/models/Presenters/Recipe.php
@@ -81,6 +81,10 @@ class Recipe extends \Robbo\Presenter\Presenter
         } else {
             $labelArray[] = '<span class="label label-success">Player Recipe</span><br>';
         }
+        $obsolete = $this->object->obsolete;
+        if ($obsolete === true) {
+            $labelArray[] = '<span class="label label-danger">Obsolete</span><br>';
+        }
 
         return implode(" ", $labelArray);
     }
@@ -90,6 +94,16 @@ class Recipe extends \Robbo\Presenter\Presenter
         $suffix = $this->object->id_suffix;
         if (stripos($suffix, "npc") !== false) {
             return '<span class="label label-warning">NPC Recipe</span>';
+        }
+        
+        return "";
+    }
+    
+    public function presentObsoleteLabel()
+    {
+        $obsolete = $this->object->obsolete;
+        if ($obsolete === true) {
+            return '<span class="label label-danger">Obsolete</span>';
         }
         
         return "";

--- a/src/app/models/Repositories/Indexers/Recipe.php
+++ b/src/app/models/Repositories/Indexers/Recipe.php
@@ -303,11 +303,12 @@ class Recipe implements IndexerInterface
                     $skill = $recipe->skill_used;
                     $level = $recipe->difficulty;
 
-                    $item = $repo->get("item.$recipe->result");
-
-                    if ($item === null) {
-                        var_dump($recipe);
-                        print "missing recipe result $recipe->result\n";
+                    if (!isset($recipe->obsolete) || $recipe->obsolete == false) {
+                        $item = $repo->get("item.$recipe->result");
+                        if ($item === null) {
+                            var_dump($recipe);
+                            print "missing recipe result $recipe->result\n";
+                        }
                     }
 
                     $repo->append("skill.$skill.$level", $item->id);

--- a/src/app/views/items/recipes.blade.php
+++ b/src/app/views/items/recipes.blade.php
@@ -39,7 +39,7 @@ var show_recipe = function(id)
 <div class="row">
   <div class="col-md-4">
 @foreach ($recipes as $recipe_id=>$local_recipe)
-{{$local_recipe->result->symbol}} <a href="#" onclick="return show_recipe('{{$recipe_id}}')">{{{ $local_recipe->result->name }}} {{ $local_recipe->npcLabel }}</a>
+{{ $local_recipe->result->symbol }} <a href="#" onclick="return show_recipe('{{$recipe_id}}')">{{{ $local_recipe->result->name }}} {{ $local_recipe->npcLabel }} {{ $local_recipe->obsoleteLabel }} </a>
 <br>
 @endforeach
 <hr>


### PR DESCRIPTION
Some recipes were adjusted or removed according to how some items were produced in game, and left as obsolete recipes. The obsolete recipes can be viewed in the browser, but the item they reference may or may not exist.