### PR TITLE
Add a temporary prefix to the requirement type to avoid item name overlap.

### DIFF
--- a/src/app/models/Repositories/Indexers/Recipe.php
+++ b/src/app/models/Repositories/Indexers/Recipe.php
@@ -28,7 +28,7 @@ class Recipe implements IndexerInterface
                 // handle group substitution of qualities, tools, and components
                 if (isset($recipe->using)) {
                     foreach ($recipe->using as $usinggroup) {
-                        $req = $repo->get("requirement.".$usinggroup[0]);
+                        $req = $repo->get("requirement."."requirement_".$usinggroup[0]);
                         if (isset($req)) {
                             // the second value multiplies the values contained in the requirement
                             $multiplier = $usinggroup[1];
@@ -129,7 +129,7 @@ class Recipe implements IndexerInterface
                                     $unit_param_3 = $similar_unit[2];
                                 }
                                 if (isset($unit_param_3) && $unit_param_3 == "LIST") {
-                                    $req = $repo->get("requirement.".$u_id);
+                                    $req = $repo->get("requirement."."requirement_".$u_id);
                                     if (isset($req) && isset($req->components)) {
                                         $successful_sub = true;
                                         foreach ($req->components as $req_similar_unit_group) {
@@ -216,7 +216,7 @@ class Recipe implements IndexerInterface
                                     $unit_param_3 = $similar_unit[2];
                                 }
                                 if (isset($unit_param_3) && $unit_param_3 == "LIST") {
-                                    $req = $repo->get("requirement.".$u_id);
+                                    $req = $repo->get("requirement."."requirement_".$u_id);
                                     if (isset($req) && isset($req->tools)) {
                                         $successful_sub = true;
                                         foreach ($req->tools as $req_similar_unit_group) {

--- a/src/app/models/Repositories/LocalRepository.php
+++ b/src/app/models/Repositories/LocalRepository.php
@@ -55,6 +55,10 @@ class LocalRepository extends Repository implements
         if(isset($object->type) && $object->type=="recipe" && isset($object->category) && $object->category=="CC_BUILDING"){
             return;
         }
+        
+        if (isset($object->type) && $object->type == "requirement") {
+            $object->id = "requirement_".$object->id;
+        }
 
         // generate a new repo ID if we are not currently processing pending objects
         if (!array_key_exists("repo_id", $object)) {
@@ -79,7 +83,7 @@ class LocalRepository extends Repository implements
             } else {
                 $tempobj = $this->simpleget($object->{'copy-from'}, null);
             }
-
+            
             // if the referenced template is not available, store it in $pending for later, or wait for the next $pending review loop
             if ($tempobj === null) {
                 if (isset($this->pending[$object->repo_id])) {


### PR DESCRIPTION
Recent changes to the JSON files have meat_cooked as a requirement and a specific food. This adds a "requirement_" prefix to the requirement object so that it isn't accidentally referenced by foods and other items inheriting from items with overlapping names.