### PR TITLE
Update Vagrant configuration to work correctly in Windows.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,4 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :private_network, type: :dhcp
   config.vm.network :forwarded_port, guest: 80, host: 8000
   config.vm.provision "shell", path: "provision.sh"
+  config.vm.provider :virtualbox do |v|
+    v.customize ["modifyvm", :id, "--memory", 2048]
+  end
 end

--- a/provision.sh
+++ b/provision.sh
@@ -29,7 +29,7 @@ curl -sS https://getcomposer.org/installer | php -- --filename=composer --instal
 
 chown $USER "$STORAGE_PATH"
 
-sudo -u $USER "$BASE_PATH"/setup.sh
+sudo -u $USER "$BASE_PATH"/vagrantsetup.sh
 
 echo "Giving access to the webserver"
 chgrp -R www-data "$STORAGE_PATH"/*

--- a/vagrantsetup.sh
+++ b/vagrantsetup.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# exit on error
+set -e
+
+# get the absolute path to the data files
+BASE_PATH=$(cd $(dirname $0 ) && pwd )
+STORAGE_PATH="src/app/storage"
+
+cd "$BASE_PATH"
+
+# download the cataclysm dda's source code
+if [ ! -e master.zip ]
+then
+    echo "Downloading game source and data files..."
+    curl -LOs https://github.com/CleverRaven/Cataclysm-DDA/archive/master.zip
+fi
+
+echo "Unzipping..."
+unzip -qo master.zip
+
+# download php dependencies
+composer -dsrc install
+php src/artisan cataclysm:rebuild Cataclysm-DDA-master
+
+echo "--------------------------"
+echo "You need to make sure the webserver can read/write to the storage path"
+echo ": $STORAGE_PATH"


### PR DESCRIPTION
The Vagrant setup uses the executable version of Composer, so the setup.sh has been copied to vagrantsetup.sh to keep the usage separate from the shared web host version.