### PR TITLE
Separate vehicle parts from the item namespace.

### DIFF
--- a/src/app/models/Item.php
+++ b/src/app/models/Item.php
@@ -108,6 +108,24 @@ class Item implements Robbo\Presenter\PresentableInterface
         return $this->repo->allModels("Item", "item.toolFor.$this->id");
     }
 
+    public function getHasVpartlist()
+    {
+        return count($this->repo->allModels("Item", "vpartlist.$this->id"));
+    }
+    
+    public function getVpartFor()
+    {
+        $vparts = $this->repo->allModels("Item", "vpartlist.$this->id");
+        $string1 = "";
+        $inner=array();
+        foreach ($vparts as $item) {
+            // build link name with name and ID to distinguish between multiple usage of vehicle part names
+            $inner[] =  link_to_route("item.view", $item->name.(substr($item->id,6) !== $item->name ? " (".substr($item->id,6).")" : ""), array("id" => $item->id));
+        }
+        
+        return "&gt; ".implode("<br>&gt; ", $inner)."\n";
+    }
+    
     public function count($type)
     {
         return $this->repo->raw("item.count.$this->id.$type", 0);

--- a/src/app/models/Repositories/Indexers/Item.php
+++ b/src/app/models/Repositories/Indexers/Item.php
@@ -101,7 +101,16 @@ class Item implements IndexerInterface
                 });
                 $repo->set("item.toolForCategory.$id.$category", $recipes);
             }
+            
+            // build item/vehicle part installation cross reference list per item
+            if (strpos($id, "vpart_") === 0) {
+                $vpart = $repo->get(self::DEFAULT_INDEX.".".$id);
+                if (isset($vpart->item)) {
+                    $repo->append("vpartlist.$vpart->item", $id);
+                }
+            }
         }
+        
         
         $repo->sort("flags");
         $repo->sort("gunmodParts");

--- a/src/app/models/Repositories/LocalRepository.php
+++ b/src/app/models/Repositories/LocalRepository.php
@@ -73,15 +73,24 @@ class LocalRepository extends Repository implements
                 $object->id = $object->abstract;
             }
         }
+        
+        // handle vpart naming replacement here so abstracts are covered
+        if (isset($object->type) && $object->type == "vehicle_part") {
+            $object->id = "vpart_".$object->id;
+        }
 
         // handle template copying in cataclysm JSON
         if (array_key_exists("copy-from", $object)) {
+            $copyfromid = $object->{'copy-from'};
+            if (isset($object->type) && $object->type == "vehicle_part") {
+                $copyfromid = "vpart_".$copyfromid;
+            }
             if (isset($object->type)&&$object->type=="recipe") {
-                $tempobj = $this->simplegetrecipe($object->{'copy-from'}, null);
+                $tempobj = $this->simplegetrecipe($copyfromid, null);
             } elseif (isset($object->type)&&$object->type=="uncraft") {
-                $tempobj = $this->simplegetuncraft($object->{'copy-from'}, null);
+                $tempobj = $this->simplegetuncraft($copyfromid, null);
             } else {
-                $tempobj = $this->simpleget($object->{'copy-from'}, null);
+                $tempobj = $this->simpleget($copyfromid, null);
             }
             
             // if the referenced template is not available, store it in $pending for later, or wait for the next $pending review loop

--- a/src/app/views/items/view.blade.php
+++ b/src/app/views/items/view.blade.php
@@ -261,6 +261,10 @@
     <br>This object is surrounded by a sickly green glow.<br>
     @endif
 
+    @if ($item->hasVpartlist)
+    <br>This item can be installed into vehicles as:<br>
+    {{$item->VpartFor}}
+    @endif
   </div>
 </div>
 <script>


### PR DESCRIPTION
Fixes accidental overlap where some vehicle parts had the same name as the item they were installed from.