### PR TITLE
Fix rifle listing and disable log spam from construction list.

### DIFF
--- a/src/app/models/Item.php
+++ b/src/app/models/Item.php
@@ -514,4 +514,21 @@ class Item implements Robbo\Presenter\PresentableInterface
         }
         return 0;
     }
+    
+    public function getRangedDamage()
+    {
+        $inner = array();
+        if (!is_numeric($this->data->ranged_damage)) {
+            if (is_array($this->data->ranged_damage)) {
+                 foreach ($this->data->ranged_damage as $indexnum=>$damageunit) {
+                     $inner[] = (is_numeric($damageunit->amount)?$damageunit->amount:"").(isset($damageunit->damage_type)?" (".$damageunit->damage_type.")":"").(isset($damageunit->armor_multiplier)?" (Armor multiplier $damageunit->armor_multiplier)":"");
+                 }
+                return implode(", ", $inner);
+            } else if (is_object($this->data->ranged_damage)){
+                $rd = $this->data->ranged_damage;
+                return (is_numeric($rd->amount)?$rd->amount:"").(isset($rd->damage_type)?" (".$rd->damage_type.")":"").(isset($rd->armor_multiplier)?" (Armor multiplier $rd->armor_multiplier)":"");
+            }
+        }
+        return $this->data->ranged_damage;
+    }
 }

--- a/src/app/models/Repositories/Repository.php
+++ b/src/app/models/Repositories/Repository.php
@@ -45,7 +45,7 @@ abstract class Repository implements RepositoryInterface
     {
         $data = $this->get("all.$id");
 
-        \Log::info("auto", array($id, $data));
+//        \Log::info("auto", array($id, $data));
         $model = ucfirst($data->type);
         $model = $this->app->make($model);
 


### PR DESCRIPTION
Fake acid weapons were causing page failures because of their multiple damage types. 