### PR TITLE
Default monster species info to "none" if it wasn't found during processing.

### DIFF
--- a/src/app/models/Repositories/Indexers/Monster.php
+++ b/src/app/models/Repositories/Indexers/Monster.php
@@ -13,6 +13,11 @@ class Monster implements IndexerInterface
     public function onNewObject(RepositoryWriterInterface $repo, $object)
     {
         if ($object->type == "MONSTER") {
+            if (!isset($object->species)) {
+                $object->species = array();
+                $object->species[] = "none";
+            }
+            
             $repo->append(self::DEFAULT_INDEX, $object->id);
             $repo->set(self::DEFAULT_INDEX.".".$object->id, $object->repo_id);
             $objspecies = (array) $object->species;


### PR DESCRIPTION
Could be related to #29.
