### PR TITLE
Add an "item disassembly" label to the item view page.

### DIFF
--- a/src/app/models/Presenters/Item.php
+++ b/src/app/models/Presenters/Item.php
@@ -107,10 +107,13 @@ class Item extends \Robbo\Presenter\Presenter
             $badges[] = '<a href="'.route("item.disassemble", $this->object->id).'"><span class="label label-info">disassemble</span></a>';
         }
         if ($this->count("recipes")) {
-            $badges[] = '<a href="'.route("item.craft", $this->object->id).'"><span class="label label-default">craft</span></a>';
+            $badges[] = '<a href="'.route("item.craft", $this->object->id).'"><span class="label label-default">craft: '.$this->count("recipes").'</span></a>';
         }
         if($this->count("construction")) {
             $badges[] = '<a href="'.route("item.construction", $this->object->id).'"><span class="label label-warning">construction: '.$this->count("construction").'</span></a>';
+        }
+        if($this->count("uncraftToolFor")) {
+            $badges[] = '<span class="label label-warning">item disassembly: '.$this->count("uncraftToolFor").'</span></a>';
         }
 
         return implode(" ", $badges);

--- a/src/app/models/Repositories/Indexers/Item.php
+++ b/src/app/models/Repositories/Indexers/Item.php
@@ -84,6 +84,11 @@ class Item implements IndexerInterface
             if ($recipes>0) {
                 $repo->set("item.count.$id.disassembledFrom", $recipes);
             }
+            
+            $recipes = count($repo->raw("item.uncraftToolFor.$id"));
+            if ($recipes>0) {
+                $repo->set("item.count.$id.uncraftToolFor", $recipes);
+            }
 
             $count = count($repo->raw("construction.$id"));
             if ($count>0) {

--- a/src/app/models/Repositories/Indexers/Recipe.php
+++ b/src/app/models/Repositories/Indexers/Recipe.php
@@ -409,11 +409,15 @@ class Recipe implements IndexerInterface
                     }
                 }
 
+                $toolfortype = "toolFor";
+                if ($recipe->type == "uncraft") {
+                    $toolfortype = "uncraftToolFor";
+                }
                 if (isset($recipe->tools)) {
                     foreach ($recipe->tools as $group) {
                         foreach ($group as $tool) {
                             list($id, $amount) = $tool;
-                            $this->linkIndexes($repo, "toolFor", $id, $recipe);
+                            $this->linkIndexes($repo, $toolfortype, $id, $recipe);
                         }
                     }
                 }
@@ -429,7 +433,7 @@ class Recipe implements IndexerInterface
                             if (isset($listval) && $listval == "LIST") {
                                 continue;
                             }
-                            $this->linkIndexes($repo, "toolFor", $id, $recipe);
+                            $this->linkIndexes($repo, $toolfortype, $id, $recipe);
 
                             if ($recipe->category == "uncraft"
                             or (isset($recipe->reversible)


### PR DESCRIPTION
Possible solution for #26. This separates the uncraft (disassembly) recipe results from the recipe label, so the recipe label should be more accurate.