### PR TITLE
Add PET_ARMOR type to the recognized item types.

### DIFF
--- a/src/app/models/Repositories/Indexers/Item.php
+++ b/src/app/models/Repositories/Indexers/Item.php
@@ -17,6 +17,7 @@ class Item implements IndexerInterface
             "AMMO", "GUN", "ARMOR", "TOOL", "TOOL_ARMOR", "BOOK", "COMESTIBLE",
             "CONTAINER", "GUNMOD", "GENERIC", "BIONIC_ITEM", "VAR_VEH_PART",
             "_SPECIAL", "MAGAZINE", "WHEEL", "TOOLMOD", "ENGINE", "VEHICLE_PART",
+            "PET_ARMOR",
         ));
 
         $this->book_types = array(


### PR DESCRIPTION
Fixes a missing recipe reference.