### PR TITLE
Simplify the item menu display for vehicle parts to reduce confusion.

### DIFF
--- a/src/app/routes.php
+++ b/src/app/routes.php
@@ -116,6 +116,15 @@ Route::group(array('after' => 'theme:layouts.bootstrap'), function () {
     ));
   });
 
+  View::composer('items.vpart_menu', function ($view) {
+    $view->with('areas', array(
+      "view" => array(
+        "route" => "item.view",
+        "label" => "Viewing installed vehicle part",
+      ),
+    ));
+  });
+
   Route::get('/{id}/craft', array(
       'as' => 'item.craft',
       'uses' => 'ItemsController@craft', )

--- a/src/app/views/items/view.blade.php
+++ b/src/app/views/items/view.blade.php
@@ -4,7 +4,11 @@
 @section('description')
 {{{$itembunch[0]->rawName}}} has a volume of {{{ $itembunch[0]->volume }}} and a weight of {{{ $itembunch[0]->weight }}}. It does {{{ $itembunch[0]->bashing }}} bashing damage and {{{ $itembunch[0]->cutting }}} cutting damage. You can find more information here.
 @endsection
+@if($itembunch[0]->isVehiclePart)
+@include('items.vpart_menu', array('active'=>'view'))
+@else
 @include('items.menu', array('active'=>'view'))
+@endif
 @foreach($itembunch as $item)
 <div class="row">
   <div class="col-md-6">

--- a/src/app/views/items/vpart_menu.blade.php
+++ b/src/app/views/items/vpart_menu.blade.php
@@ -1,0 +1,21 @@
+<nav class="navbar navbar-default" role="navigation">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#item-menu">
+        <span class="sr-only">Toggle menu</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      {{ link_to_route($areas["view"]["route"], "Menu", array("id"=>$itembunch[0]->id), array("class"=>"navbar-brand")) }}
+    </div>
+
+    <div class="collapse navbar-collapse" id="item-menu">
+      <ul class="nav navbar-nav">
+        @foreach($areas as $area=>$data)
+        <li{{ $area==$active?' class="active"':''}}>{{ link_to_route($data["route"], $data["label"], array("id"=>$itembunch[0]->id)) }}
+        @endforeach
+      </ul>
+    </div>
+  </div>
+</nav>


### PR DESCRIPTION
Reduces the menu for vehicle parts to just the view menu, no other options are currently relevant.