### PR TITLE
Volume and container update

### DIFF
--- a/src/app/models/Item.php
+++ b/src/app/models/Item.php
@@ -508,7 +508,7 @@ class Item implements Robbo\Presenter\PresentableInterface
 
     public function getContains()
     {
-        return $this->data->contains / 4.0;
+        return $this->data->contains;
     }
 
     public function getConstructionUses()

--- a/src/app/models/Presenters/Item.php
+++ b/src/app/models/Presenters/Item.php
@@ -250,27 +250,22 @@ class Item extends \Robbo\Presenter\Presenter
 
     public function presentRigid()
     {
-        return $this->object->rigid ? "y" : "n";
+        return $this->object->rigid ? "R" : "";
     }
 
     public function presentSeals()
     {
-        return $this->object->seals ? "y" : "n";
+        return $this->object->seals ? "S" : "";
     }
 
     public function presentWatertight()
     {
-        return $this->object->watertight ? "y" : "n";
+        return $this->object->watertight ? "W" : "";
     }
 
     public function presentPreserves()
     {
-        return $this->object->preserves ? "y" : "n";
-    }
-
-    public function presentContains()
-    {
-        return number_format($this->object->contains, 2);
+        return $this->object->preserves ? "P" : "";
     }
 
     public function presentTechniques()

--- a/src/app/models/Repositories/Indexers/Item.php
+++ b/src/app/models/Repositories/Indexers/Item.php
@@ -268,13 +268,17 @@ class Item implements IndexerInterface
         // handle "ml" indicators in volume/container volume
         if (isset($object->volume) && is_string($object->volume)) {
             if (stripos($object->volume, "ml") !== false) {
-                $object->volume = (substr($object->volume, 0, -2) * 4.0) / 1000.0;
+                $object->volume = $object->volume / 1000.0;
             }
+
+            $object->volume = $object->volume * 1.0;
         }
         if (isset($object->contains) && is_string($object->contains)) {
             if (stripos($object->contains, "ml") !== false) {
-                $object->contains = substr($object->contains, 0, -2) / 1000.0;
+                $object->contains = $object->contains / 1000.0;
             }
+
+            $object->contains = $object->contains * 1.0;
         }
         // adjust volume for low volume large stack size ammunition
         if ($object->type == "AMMO") {
@@ -285,8 +289,25 @@ class Item implements IndexerInterface
             }
         }
 
-        if ($object->type == "CONTAINER") {
+        if ($object->type == "CONTAINER" || isset($object->container_data)) {
             $repo->append("container", $object->id);
+            if (isset($object->container_data)) {
+                if (isset($object->container_data->contains)) {
+                    $object->contains = $object->container_data->contains;
+                }
+                if (isset($object->container_data->watertight)) {
+                    $object->watertight = $object->container_data->watertight;
+                }
+                if (isset($object->container_data->seals)) {
+                    $object->seals = $object->container_data->seals;
+                }
+            }
+
+            if (stripos($object->contains, "ml") !== false) {
+                $object->contains = $object->contains / 1000.0;
+            }
+            $object->contains = $object->contains * 1.0;
+
         }
         if ($object->type == "COMESTIBLE") {
             $repo->append("food", $object->id);

--- a/src/app/views/items/view.blade.php
+++ b/src/app/views/items/view.blade.php
@@ -24,7 +24,7 @@
     @if (!$item->isVehiclePart)
     <br>
     <br>
-    Volume: {{{ $item->volume/4.0 }}} L Weight: {{ $item->weight }} lbs /{{ $item->weightMetric }} kg<br>
+    Volume: {{{ $item->volume }}} L Weight: {{ $item->weight }} lbs /{{ $item->weightMetric }} kg<br>
       Bash: {{{ $item->bashing }}}
       @if ($item->hasFlag("SPEAR"))
       Pierce: {{{ $item->piercing }}}
@@ -185,16 +185,16 @@
     @endif
 
     @if ($item->isContainer)
-    @if ($item->rigid=='y')
+    @if ($item->rigid=='R')
       This item is rigid.<br>
     @endif
-    @if ($item->seals=='y')
+    @if ($item->seals=='S')
       This container can be resealed.<br>
     @endif
-    @if ($item->watertight=='y')
+    @if ($item->watertight=='W')
       This container is watertight.<br>
     @endif
-    @if ($item->preserves=='y')
+    @if ($item->preserves=='P')
       This container preserves its contents from spoiling.<br>
     @endif
       This container can store {{ $item->contains }} liters.<br>


### PR DESCRIPTION
Some containers were using a different JSON structure to show container capacity, so some items were missing from the container list. Also fixes volume calculation on item page. Specifically fixes the error page from viewing containers in #54. The container list was updated to be easier to check the columns for container properties, abbreviated by the first letter of the container property (seals, watertight, preserves).