### PR TITLE
Exclude items that do not need ranged damage processing.

### DIFF
--- a/src/app/models/Item.php
+++ b/src/app/models/Item.php
@@ -326,12 +326,14 @@ class Item implements Robbo\Presenter\PresentableInterface
         $ammotypes = $this->repo->allModels("Item", "ammo.$this->ammo");
         foreach ($ammotypes as &$ammotype) {
             $ammo_damage_multiplier = 1.0;
-            if ($ammotype->prop_damage > 0) {
+            if ($this->data->type == "GUN" && $ammotype->prop_damage > 0) {
                 $ammo_damage_multiplier = $ammotype->prop_damage;
             }
     
             $result = $ammotype->damage;
-            $result = $result + ($this->data->ranged_damage * $ammo_damage_multiplier);
+            if ($this->data->type == "GUN") {
+                $result = $result + ($this->data->ranged_damage * $ammo_damage_multiplier);
+            }
             $ammotype->damage = $result;
         }
         unset($ammotype);


### PR DESCRIPTION
Bows and crossbows should still apply the newer proportional arrow damage calculations, and fuel based items (chainsaws, etc) should display properly. Applies to #54.