### PR TITLE
Calculate monster's difficulty

### DIFF
--- a/src/app/models/Presenters/Monster.php
+++ b/src/app/models/Presenters/Monster.php
@@ -135,4 +135,25 @@ class Monster extends \Robbo\Presenter\Presenter
             return $this->object->size;
         }
     }
+
+
+    public function presentDifficulty()
+    {
+        $diff = $this->object->difficulty;
+        if ($diff < 3) {
+            $strvalue = 'Minimal threat.';
+        } else if ($diff < 10) {
+            $strvalue = 'Mildly dangerous.';
+        } else if ($diff < 20) {
+            $strvalue = 'Dangerous.';
+        } else if ($diff < 30) {
+            $strvalue = 'Very dangerous.';
+        } else if ($diff < 50) {
+            $strvalue = 'Extremely dangerous.';
+        } else {
+            $strvalue = 'Fatally dangerous!';
+        }
+        $diff = floor($diff);
+        return "$diff ($strvalue)";
+    }
 }

--- a/src/app/models/Repositories/Indexers/Monster.php
+++ b/src/app/models/Repositories/Indexers/Monster.php
@@ -27,12 +27,34 @@ class Monster implements IndexerInterface
                 $repo->addUnique("monster.species", $species);
             }
 
-            ValueUtil::SetDefault($object, "melee_skill", 0);
-            ValueUtil::SetDefault($object, "melee_dice_sides", 0);
-            ValueUtil::SetDefault($object, "melee_cut", 0);
-            ValueUtil::SetDefault($object, "melee_dice", 0);
-            ValueUtil::SetDefault($object, "aggression", 0);
-            ValueUtil::SetDefault($object, "morale", 0);
+            $default_values = array(
+                "melee_skill" => 0,
+                "melee_dice_sides" => 0,
+                "melee_cut" => 0,
+                "melee_dice" => 0,
+                "aggression" => 0,
+                "morale" => 0,
+                "dodge" => 0,
+                "diff" => 0,
+                "armor_cut" => 0,
+                "armor_bash" => 0,
+                "emit_fields" => array(),
+                "vision_day" => 40,
+                "vision_night" => 1,
+                "special_attacks" => array(),
+                "speed" => 100,
+                "attack_cost" => 100,
+            );
+            foreach ($default_values as $k => $v) {
+                ValueUtil::SetDefault($object, $k, $v);
+            }
+
+            $diff = ($object->melee_skill + 1) * $object->melee_dice * ($object->melee_cut + $object->melee_dice_sides) * 0.04 +
+                ($object->dodge + 1) * (3 + $object->armor_bash + $object->armor_cut) * 0.04 +
+                ($object->diff + count($object->special_attacks) + 8 * count($object->emit_fields));
+            $diff *= ($object->hp + $object->speed - $object->attack_cost + ($object->morale + $object->aggression) * 0.1) * 0.01 +
+                ($object->vision_day + 2 * $object->vision_night) * 0.01;
+            $object->difficulty = $diff;
 
             return;
         }

--- a/src/app/views/monsters/view.blade.php
+++ b/src/app/views/monsters/view.blade.php
@@ -82,7 +82,7 @@ Monster ID: {{{$monster->id}}}
 </tr>
 <tr>
   <td>Difficulty:</td>
-  <td>{{{$monster->diff}}}</td>
+  <td>{{{$monster->difficulty}}}</td>
 </tr>
 <tr>
   <td valign="top">Flags:</td>


### PR DESCRIPTION
Currently, the difficulty of the monster hasn't been calculated correctly (eg http://cdda-trunk.chezzo.com/monsters/mon_zombie_soldier_acid_1).
The `diff` value used now is not the final difficulty of monster, but the "[difficulty from special attacks](https://github.com/CleverRaven/Cataclysm-DDA/blob/a7e33210afb248a47f2f4a34aaa5129e95a4a812/src/mtype.h#L247)"

# Original algorithm
Difficulty level: https://github.com/CleverRaven/Cataclysm-DDA/blob/3040792b6b4d95e77fe4f02ad3989fcfce8d789f/src/monster.cpp#L642-L654

How to calculate: https://github.com/CleverRaven/Cataclysm-DDA/blob/3040792b6b4d95e77fe4f02ad3989fcfce8d789f/src/monstergenerator.cpp#L812-L816

I'm not familiar with PHP, so the code may not be very neat. I'm glade to see your advice : )


