### PR TITLE
Fix bug of parsing default.json

### DIFF
--- a/src/models/Repositories/LocalRepository.php
+++ b/src/models/Repositories/LocalRepository.php
@@ -379,7 +379,7 @@ class LocalRepository extends Repository implements RepositoryInterface, Reposit
         $paths = array("$path/data/core", "$path/data/json");
 
         // add default-loaded mods to the path list
-        foreach ($default_mods_data->dependencies as $mod) {
+        foreach ($default_mods_data[0]->dependencies as $mod) {
             $paths[] = $this->modDirectory($path, $mod);
         }
 


### PR DESCRIPTION
This was introduced in https://github.com/CleverRaven/Cataclysm-DDA/pull/41652.

Which change

```json
{
  "type": "MOD_INFO",
  "ident": "dev:default",
  "name": "default",
  "description": "contains all the mods recommended by the developers",
  "dependencies": [
    "dda",
    "no_npc_food"
  ]
}
```

into

```json
[
	{
	  "type": "MOD_INFO",
	  "ident": "dev:default",
	  "name": "default",
	  "description": "contains all the mods recommended by the developers",
	  "dependencies": [
	    "dda",
	    "no_npc_food"
	  ]
	}
]
```
