### PR TITLE
Fix bug when 'material' is an empty array

### DIFF
--- a/src/models/Item.php
+++ b/src/models/Item.php
@@ -24,7 +24,7 @@ class Item implements Robbo\Presenter\PresentableInterface
 
     public function load($data)
     {
-        if (!isset($data->material)) {
+        if (!isset($data->material) || (is_array($data->material) && count($data->material) === 0)) {
             $data->material = array("null", "null");
         }
         if (!is_array($data->material)) {


### PR DESCRIPTION
Fix 500 error of https://cdda-trunk.chezzo.com/melee

Caused by empty material.

https://github.com/CleverRaven/Cataclysm-DDA/blob/f5505090839ed3f750d90b0d80dad567e7d5a75a/data/mods/Magiclysm/items/ethereal_items.json#L242

```
    "material": [  ],
```