### PR TITLE
Add a category to recipes that are lacking it due to using the id_suffix to describe the recipe type.

### DIFF
--- a/src/models/Repositories/Indexers/Recipe.php
+++ b/src/models/Repositories/Indexers/Recipe.php
@@ -434,6 +434,14 @@ class Recipe implements IndexerInterface
 
                 ValueUtil::SetDefault($recipe, "difficulty", 0);
 
+                if (!isset($recipe->category)) {
+                    if (isset($recipe->id_suffix)) {
+                        $recipe->category = "uncategorized_".$recipe->id_suffix;
+                    } else {
+                        $recipe->category = "uncategorized";
+                    }
+                }
+
                 $repo->append(self::DEFAULT_INDEX, $recipe->repo_id);
                 $repo->set(self::DEFAULT_INDEX.".".$recipe->repo_id, $recipe->repo_id);
 


### PR DESCRIPTION
Affects a couple items like xl_armor_lightplate.