### PR TITLE
Add an enum processor to handle To-Hit string values that are specified in JSON.

### DIFF
--- a/src/models/Repositories/Indexers/CustomUtility/ToHitEnumConversion.php
+++ b/src/models/Repositories/Indexers/CustomUtility/ToHitEnumConversion.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace CustomUtility;
+
+class ToHitEnumConversion
+{
+    public static function GripStringToInt($valueString)
+    {
+        $result = 0;
+        switch(strtolower($valueString)){
+            case "bad":
+                $result = -1;
+            break;
+            case "none":
+                $result = 0;
+            break;
+            case "solid":
+                $result = 1;
+            break;
+            case "weapon":
+                $result = 2;
+            break;
+        }
+        
+        return $result;
+    }
+
+    public static function LengthStringToInt($valueString)
+    {
+        $result = 0;
+        switch(strtolower($valueString)){
+            case "hand":
+                $result = 0;
+            break;
+            case "short":
+                $result = 1;
+            break;
+            case "long":
+                $result = 2;
+            break;
+        }
+        
+        return $result;
+    }
+
+    public static function SurfaceStringToInt($valueString)
+    {
+        $result = 0;
+        switch(strtolower($valueString)){
+            case "point":
+                $result = -2;
+            break;
+            case "line":
+                $result = -1;
+            break;
+            case "any":
+                $result = 0;
+            break;
+            case "every":
+                $result = 1;
+            break;
+        }
+        
+        return $result;
+    }
+
+    public static function BalanceStringToInt($valueString)
+    {
+        $result = 0;
+        switch(strtolower($valueString)){
+            case "clumsy":
+                $result = -2;
+            break;
+            case "uneven":
+                $result = -1;
+            break;
+            case "neutral":
+                $result = 0;
+            break;
+            case "good":
+                $result = 1;
+            break;
+        }
+        
+        return $result;
+    }
+}

--- a/src/models/Repositories/Indexers/Item.php
+++ b/src/models/Repositories/Indexers/Item.php
@@ -4,6 +4,7 @@ namespace Repositories\Indexers;
 
 use Repositories\RepositoryWriterInterface;
 use CustomUtility\ValueUtil;
+use CustomUtility\ToHitEnumConversion;
 
 class Item implements IndexerInterface
 {
@@ -427,7 +428,26 @@ class Item implements IndexerInterface
             $damagecheck += $object->cutting;
         }
         if (isset($object->to_hit)) {
-            $damagecheck += $object->to_hit;
+            if (is_numeric($object->to_hit)) {
+                $damagecheck += $object->to_hit;
+            } else {
+                $to_hit = 0;
+                if (isset($object->to_hit->grip)) {
+                    $to_hit+= ToHitEnumConversion::GripStringToInt($object->to_hit->grip);
+                }
+                if (isset($object->to_hit->length)) {
+                    $to_hit+= ToHitEnumConversion::LengthStringToInt($object->to_hit->length);
+                }
+                if (isset($object->to_hit->surface)) {
+                    $to_hit+= ToHitEnumConversion::SurfaceStringToInt($object->to_hit->surface);
+                }
+                if (isset($object->to_hit->balance)) {
+                    $to_hit+= ToHitEnumConversion::BalanceStringToInt($object->to_hit->balance);
+                }
+                $object->to_hit = $to_hit;
+
+                $damagecheck += $object->to_hit;
+            }
         }
         if ($damagecheck >= 8 && strtoupper($object->type) != "VEHICLE_PART" && isset($object->weight) && $object->weight < 15000 && (!isset($object->dispersion) || $object->dispersion == 0)) {
             $repo->append("melee", $object->id);


### PR DESCRIPTION
This was observed with the butcher knife and related knives that were using a to_hit string containing `{ "grip": "weapon", "length": "short", "surface": "point", "balance": "neutral" }`